### PR TITLE
Adding c-style multiline comments, ca65 supports via .FEATURE c_comments

### DIFF
--- a/syntax/asm_ca65.vim
+++ b/syntax/asm_ca65.vim
@@ -263,6 +263,9 @@ syn region asm_ca65Char     start=+'+ skip=+\\'+ end=+'+
 syn match asm_ca65Comment   ";.*" contains=asm_ca65Todo,@Spell
 syn keyword asm_ca65Todo    contained TODO FIXME XXX HACK
 
+" C-style comments, via .FEATURE c_comments
+syn region asm_ca65Comment   start=+\//*.*+ end=+\*\/+
+
 syn case match
 
 " Define the default highlighting.


### PR DESCRIPTION
Adding multi-line comments, a la
```
lda #$20
/*
sta $2006
lda #$00
sta $2006
*/
```

enabled via
```
.FEATURE c_comments
```
